### PR TITLE
fix: resolve parameter binding conflict in Managers parameter

### DIFF
--- a/scan-shai-hulud.ps1
+++ b/scan-shai-hulud.ps1
@@ -83,7 +83,7 @@ param(
   [Parameter(Position = 3, ValueFromRemainingArguments = $false)]
   [string[]]$Exclude = @('**/node_modules/**', '**/.pnpm-store/**', '**/dist/**', '**/build/**', '**/tmp/**', '**/.turbo/**'),
   [Parameter(Position = 4, ValueFromRemainingArguments = $false)]
-  [string[]]$Managers = @('yarn', 'npm', 'pnpm', 'bun'),
+  [string[]]$Managers,
   [switch]$Detailed,   # default true unless -Summary
   [switch]$Summary,
   [switch]$OnlyAffected,
@@ -100,6 +100,11 @@ if ($Help) {
 }
 
 # Path validation is now handled by ValidateScript attributes
+
+# Handle Managers parameter - set default if not provided
+if (-not $Managers -or $Managers.Count -eq 0) {
+  $Managers = @('yarn', 'npm', 'pnpm', 'bun')
+}
 
 # Handle comma-separated managers string and validate
 $validManagers = @('yarn', 'npm', 'pnpm', 'bun')


### PR DESCRIPTION
- Remove default value from Managers parameter to prevent binding conflicts
- Set default value programmatically in script logic instead
- Fix 'Cannot bind parameter because parameter Managers is specified more than once' error
- Maintain backward compatibility with comma-separated string inputs